### PR TITLE
Update _toc.yml

### DIFF
--- a/docs/_toc.yml
+++ b/docs/_toc.yml
@@ -9,7 +9,7 @@ parts:
       - file: docs/data
   - caption: Data Products
     chapters:
-      - file: notebooks/conflict/conflict-in-niger.ipynb
+      - file: notebooks/conflict/Niger Conflict Data.ipynb
       - file: reports/agriculture/report.ipynb
         sections:
           - file: notebooks/agriculture/drought.ipynb


### PR DESCRIPTION
Hi Gabriel,

I observed that the old notebook is still showing on the web book shared with the team, so I just modified accordingly. 

It would be good to delete the old notebook (conflict-in-niger.ipynb) and retain only the updated notebook (Niger Conflict Data.ipynb).